### PR TITLE
feat(application, useChallenge): add creatorType field for challenge …

### DIFF
--- a/src/helper/model/application.ts
+++ b/src/helper/model/application.ts
@@ -55,7 +55,8 @@ export interface ICompetition {
     endDate: string;
     tracks: string[]
     industry: string;
-    organizationId?: string
+    organizationId?: string;
+    creatorType?: "USER" | "ORGANIZATION"
 }
 
 export interface IEmailBlast {

--- a/src/hook/useChallenge.ts
+++ b/src/hook/useChallenge.ts
@@ -683,7 +683,7 @@ const useChallenge = (
         },
     });
 
-    const formikChallenge = useFormik({
+    const formikChallenge = useFormik<ICompetition>({
         initialValues: {
             // thumbnail: "",
             isPublic: true,

--- a/src/hook/useChallenge.ts
+++ b/src/hook/useChallenge.ts
@@ -458,18 +458,26 @@ const useChallenge = (
                     editChallenge.mutate({
                         ...payload,
                         organizationId: organisationId + "",
+                        creatorType: "ORGANIZATION"
                     });
                 } else {
-                    editChallenge.mutate(payload);
+                    editChallenge.mutate({
+                        ...payload,
+                        creatorType: "USER"
+                    });
                 }
             } else {
                 if (organisationId) {
                     createChallenge.mutate({
                         ...payload,
                         organizationId: organisationId + "",
+                        creatorType: "ORGANIZATION"
                     });
                 } else {
-                    createChallenge.mutate(payload);
+                    createChallenge.mutate({
+                        ...payload,
+                        creatorType: "USER"
+                    });
                 }
             }
         },
@@ -675,7 +683,7 @@ const useChallenge = (
         },
     });
 
-    const formikChallenge = useFormik<ICompetition>({
+    const formikChallenge = useFormik({
         initialValues: {
             // thumbnail: "",
             isPublic: true,
@@ -726,9 +734,13 @@ const useChallenge = (
                     editChallenge.mutate({
                         ...data,
                         organizationId: organisationId + "",
+                        creatorType: "ORGANIZATION"
                     });
                 } else {
-                    editChallenge.mutate(data);
+                    editChallenge.mutate({
+                        ...data,
+                        creatorType: "USER"
+                    });
                 }
                 return;
             } else if (image) {


### PR DESCRIPTION
…management

- Introduced a new optional field `creatorType` in the ICompetition interface to differentiate between user and organization creators.
- Updated challenge mutation logic in the useChallenge hook to set `creatorType` based on the presence of organizationId, enhancing challenge creation and editing functionality.