### PR TITLE
feat(ChatLayout, ChallengeForm): enhance meeting link functionality

### DIFF
--- a/src/components/challenges/chats/chatLayout.tsx
+++ b/src/components/challenges/chats/chatLayout.tsx
@@ -32,7 +32,7 @@ export default function ChatLayout({ item }: { item: IChallenge }) {
     const [tab, setTab] = useState("chat");
     const tablink = [
         { label: "Messages", key: "chat", icon: RiChatSmile2Line },
-        { label: "Meeting", key: "meeting", icon: RiVideoChatLine },
+        { label: "Live Session", key: "meeting", icon: RiVideoChatLine },
         { label: "Announcements", key: "announcement", icon: GrAnnounce },
         // { label: "Help", key: "help" },
         // { label: "Coaches", key: "coaches" },
@@ -115,7 +115,7 @@ export default function ChatLayout({ item }: { item: IChallenge }) {
                     >
                         <div className="w-full flex h-full flex-col justify-end  gap-2 py-1">
                             {item?.meetingLink ? (
-                                <a target="_blank" href={item?.url} className=" text-primary ">
+                                <a target="_blank" href={item?.meetingLink} className=" text-primary ">
                                     Join Meeting
                                 </a>
                             ) : (

--- a/src/components/forms/challenge.tsx
+++ b/src/components/forms/challenge.tsx
@@ -97,7 +97,12 @@ export default function ChallengeForm(
                         placeholder="Select a level"
                     />
                 </LoadingLayout>
-
+                <CustomInput
+                    name="meetingLink"
+                    label="Meeting Link"
+                    placeholder=""
+                    type="url"
+                /> 
                 <LoadingLayout loading={loadingindustry} >
                     <CustomSelect
                         name="industry"

--- a/src/helper/model/application.ts
+++ b/src/helper/model/application.ts
@@ -56,7 +56,8 @@ export interface ICompetition {
     tracks: string[]
     industry: string;
     organizationId?: string;
-    creatorType?: "USER" | "ORGANIZATION"
+    creatorType?: "USER" | "ORGANIZATION";
+    meetingLink?:  string
 }
 
 export interface IEmailBlast {


### PR DESCRIPTION
- Updated ChatLayout to rename the "Meeting" tab to "Live Session" for better clarity.
- Modified the ChatLayout to correctly link to the meeting URL from the challenge item.
- Added a new input field for "Meeting Link" in the ChallengeForm to allow users to specify a meeting URL.
- Introduced a meetingLink property in the application model to support the new functionality.