### PR TITLE
feat(Challenges): add isPublic parameter to challenge requests

### DIFF
--- a/src/components/challenges/trackChallenges.tsx
+++ b/src/components/challenges/trackChallenges.tsx
@@ -33,7 +33,8 @@ export default function TrackChallenges() {
         endpoint: `/challenge?${params.toString()}`, name: "challenge", params: {
             userId: user?._id as string,
             isApproved: "true",
-            limit: 20
+            limit: 20,
+            isPublic: "true",
         }
     })
 

--- a/src/components/dashboard/listChallenges.tsx
+++ b/src/components/dashboard/listChallenges.tsx
@@ -22,7 +22,8 @@ export default function ListChallenges() {
     };
 
     const { data, isLoading } = useFetchData<IChallenge[]>({ endpoint: "/challenge", name: "challenge", params : {
-        isApproved: "true"
+        isApproved: "true",
+        isPublic: "true",
     }})
 
     return (

--- a/src/components/explore/exploreChallenges.tsx
+++ b/src/components/explore/exploreChallenges.tsx
@@ -23,7 +23,8 @@ export default function ExploreChallenges() {
 
     const { data, isLoading } = useUnsecureFetchData<IChallenge[]>({
         endpoint: `/challenge?${params.toString()}`, name: "challenge", params: {
-            isApproved: "true"
+            isApproved: "true",
+            isPublic: "true",
         }
     })
 


### PR DESCRIPTION
- Updated challenge data fetching in TrackChallenges, ListChallenges, and ExploreChallenges components to include the isPublic parameter, ensuring only public challenges are retrieved.